### PR TITLE
Spira app function signature updates

### DIFF
--- a/docs/Developers/SpiraApps-Manager.md
+++ b/docs/Developers/SpiraApps-Manager.md
@@ -68,7 +68,7 @@ To make REST calls to an external service, SpiraApps should always use the spira
 
 The **executeRest** function call takes a large set of parameters to fully prepare the API call. This includes callback functions for success and failure of the API call.
 
-=== "Explanation"
+=== "Parameters"
     - **appGuid**: the APP_GUID of the SpiraApp used to access system settings like authentication tokens (string)
     - **appName**: the name of the SpiraApp used for logging purposes only (string)
     - **method**: the verb to use for this call, with accepted values being "POST" (default), "GET", "PUT", "DELETE", "PATCH", "OPTIONS", or "MERGE" (string)
@@ -412,10 +412,9 @@ A SpiraApp can make requests to Spira to perform certain actions on certain page
 
 ## UX generator
 ### Dropdown list dialog
-This helper function handles the creation of a UX control that allows users to interact with it freely. It creates a modal dialog box where users can choose a value from a dropdown list, and then trigger an action in a SpiraApp based off that choice.
+The helper function `createComboDialog` creates a modal dialog box where users can choose a value from a dropdown list, and then trigger an action in a SpiraApp based off that choice.
 
-=== "Explanation"
-    The `createComboDialog` function takes the following parameters:
+=== "Parameters"
 
     - **title**: the title of the dialog (string)
     - **introText**: the introductory text, to explain to the user what to do and why (string)
@@ -453,7 +452,7 @@ This helper function handles the creation of a UX control that allows users to i
 ## User Permission Checks
 The SpiraAppManager provides a number of helpers to let SpiraApps better understand the current context of the user. Some of these have been discussed above. The following functions provide checks that can be useful in building up a SpiraApp's logic.
 
-=== "Explanation"
+=== "Available Checks"
     ??? note "canViewArtifactType(artifactTypeId: number)" 
         Returns true if the current user can **view** the specified [artifact type](./SpiraApps-Reference.md/#artifact-types) for the current product.
 

--- a/docs/Developers/SpiraApps-Manager.md
+++ b/docs/Developers/SpiraApps-Manager.md
@@ -10,7 +10,7 @@ The following ID fields are available from the spiraAppManager. They are useful 
     - **artifactId**: returns the ID of the current artifact (integer). Note that this will be correctly populated on details pages only, and not when creating new incidents or risks
     - **displayReleaseId**: returns the ID of the release being displayed (integer). This is used on product and reporting home pages - otherwise it is an empty string.
    
-=== "Example"
+=== "Examples"
 
     ```js
     const userId = spiraAppManager.userId; // e.g. 5
@@ -217,7 +217,7 @@ SpiraApps can show and hide messages to the user to provide them with informatio
     ??? note "**hideMessage()**" 
         Hides any currently displayed message. This is useful when a SpiraApp needs to show a message during an operation, but hide after the operation is complete. 
 
-=== "Example Usage"
+=== "Examples"
 
     ```js
     spiraAppManager.displayErrorMessage("The operation could not complete due to the following error: " + errorMessage);
@@ -396,7 +396,7 @@ A SpiraApp can make requests to Spira to perform certain actions on certain page
 
         - **URL**: URL to navigate the user's browser to 
 
-=== "Example Usage"
+=== "Examples"
 
     ```js
     spiraAppManager.reloadForm();
@@ -467,7 +467,7 @@ The SpiraAppManager provides a number of helpers to let SpiraApps better underst
 
         - **artifactTypeId**: ID of the artifact type we want to check permissions for 
 
-=== "Example"
+=== "Examples"
 
     ```js
     spiraAppManager.canViewArtifactType(1); // returns true if the user can view requirements in this product
@@ -501,7 +501,7 @@ The SpiraAppManager provides a number of helpers to let SpiraApps better underst
 
         - **htmlToSanitize**: String of HTML which is going to be rendered to the DOM from user input, such as in a dashboard widget rendering the description of an artifact
 
-=== "Example"
+=== "Examples"
 
     ```js
     spiraAppManager.formatDate("1993-05-16T14:48:00.000Z"); // returns "5/16/1993" if the user's culture is en-US
@@ -540,9 +540,9 @@ Do not use this for storing secure information.
 === "Best Practices"
     Always use your APP_GUID as a prefix / suffix of the local storage keys your SpiraApp uses to avoid conflicts with other SpiraApps. Define these keys as constants at the top of the JS file. 
     
-    Your SpiraApp will likely not be distributed by Inflectra if you fail to follow this rule, since it puts localStorage based functionality of Spira & other SpiraApps at risk.
+    Your SpiraApp will likely not be distributed by Inflectra if you fail to follow this rule, since it could put localStorage based functionality of Spira & other SpiraApps at risk.
 
-=== "Example"
+=== "Examples"
 
     ```js linenums="1"
     // use a single object to store all the settings in memory

--- a/docs/Developers/SpiraApps-Manager.md
+++ b/docs/Developers/SpiraApps-Manager.md
@@ -449,10 +449,10 @@ The helper function `createComboDialog` creates a modal dialog box where users c
     ```
 
 
-## User Permission Checks
-The SpiraAppManager provides a number of helpers to let SpiraApps better understand the current context of the user. Some of these have been discussed above. The following functions provide checks that can be useful in building up a SpiraApp's logic.
+## User Context 
+The SpiraAppManager provides a number of functions to let SpiraApps better understand the current context of the user. Some of these have been discussed above. The following functions provide checks that can be useful in building up a SpiraApp's logic based on information about the user's account.
 
-=== "Available Checks"
+=== "Available Context"
     ??? note "canViewArtifactType(artifactTypeId: number)" 
         Returns true if the current user can **view** the specified [artifact type](./SpiraApps-Reference.md/#artifact-types) for the current product.
 

--- a/docs/Developers/SpiraApps-Manager.md
+++ b/docs/Developers/SpiraApps-Manager.md
@@ -163,7 +163,7 @@ SpiraApps can make API calls to the Amazon Web Services (AWS) Generative Artific
 
 The **executeAwsBedrockRuntime** function call makes a REST API call to the AWS Bedrock Runtime service. It uses an AWS Access Key and Access Key Secret. The latter needs to be stored as a secure setting.
 
-=== "Explanation"
+=== "Parameters"
     - **appGuid**: the APP_GUID of the SpiraApp used to access system settings like authentication tokens (string)
     - **appName**: the name of the SpiraApp used for logging purposes only (string)
     - **accessKeyId**: the value of the AWS Access Key that should be used to make the API call (string)
@@ -207,13 +207,17 @@ The **executeAwsBedrockRuntime** function call makes a REST API call to the AWS 
 ## Notifications
 SpiraApps can show and hide messages to the user to provide them with information about the success or failure of actions taken by the SpiraApp. The different message types show different visual cues to the user. The messages are all displayed as a modal message
 
-=== "Explanation"
-    - **displayErrorMessage**: shows an error message to the user, accepting a single string from the SpiraApp
-    - **displaySuccessMessage**: shows a success message to the user, accepting a single string from the SpiraApp
-    - **displayWarningMessage**: shows a warning to the user, accepting a single string from the SpiraApp
-    - **hideMessage**: hides the message, if any. This is useful when a SpiraApp needs to show a message during an operation, but hide after the operation is complete
+=== "Available Actions"
+    ??? note "**displayErrorMessage(message: string)**" 
+        Shows an error message to the user 
+    ??? note "**displaySuccessMessage(message: string)**" 
+        Shows a success message to the user
+    ??? note "**displayWarningMessage(message: string)**" 
+        Shows a warning message to the user
+    ??? note "**hideMessage()**" 
+        Hides any currently displayed message. This is useful when a SpiraApp needs to show a message during an operation, but hide after the operation is complete. 
 
-=== "Example"
+=== "Example Usage"
 
     ```js
     spiraAppManager.displayErrorMessage("The operation could not complete due to the following error: " + errorMessage);
@@ -231,7 +235,7 @@ SpiraApps can create [menu entries](./SpiraApps-Overview.md/#menus) on [relevant
 
 Use the `registerEvent_menuEntryClick` function on the spiraAppManager to register the function to execute when a menu entry is clicked.
 
-=== "Explanation"
+=== "Parameters"
     - **appGuid**: the guid of the SpiraApp as stored in APP_GUID (string)
     - **menuEntry**: the exact "name" property as set in the manifest for the specific menu entry(string, case-sensitive)
     - **handler**: function to execute
@@ -252,20 +256,40 @@ Use the `registerEvent_menuEntryClick` function on the spiraAppManager to regist
 ## Events handlers
 There are a number of events that a SpiraApp can register against. This allows SpiraApps to take specific actions at relevant times based on the wider flow on the page.
 
-=== "Explanation"
-    - **registerEvent_windowLoad**: registers an event handler to run on full page load (e.g. to load a dashboard widget on page load). Note that while the page may be fully loaded, some data or logic on the page may still be processing or loading.
-    - **registerEvent_dashboardUpdated**: registers an event handler on dashboard pages when the release dropdown is changed. This can be useful when a user changes the release on the product dashboard.
+=== "Details Page"
 
-    **Details page events**:
+    ??? note "registerEvent_dataSaved(handler: (operation: string, newId: number) => void)" 
+        Registers an event handler on a details page to trigger when the main form data is saved. 
 
-    - **registerEvent_dataSaved**: registers an event handler on a details page to trigger when the main form data is saved. When the handler is called, an operation and artifactId parameters are passed into the handler
-    - **registerEvent_loaded**: registers an event handler on the details page to trigger when the main form data is loaded. When the handler is called, a boolean is provided back to the SpiraApp as a parameter, which should be ignored (internal use only). Note that this will be triggered each time the data is refreshed, including switching between artifacts without a full page load
-    - **registerEvent_dataFailure**: registers an event handler on the details page form manager for when data is not saved correctly. Receives an exception message from Spira - this may be useful to help a SpiraApp debug, but should not be presented to the user.
-    - **registerEvent_operationReverted**: Registers an event handler on the details page form manager for when a status change is reverted back. When the handler is called, the current status id and a boolean on if it is an open status (where relevant) are provided as parameters
-    - **registerEvent_dropdownChanged**: Registers an event handler on the [specified dropdown field](./SpiraApps-Reference.md/#available-field-names) for when its value changes. When the handler is called, the old and new values are provided (as ints). The handler can block the update by returning false or an error. Note that on first registering the handler, this function returns true if the handler was registered, and false if the handler could not be registered.  
+        - **operation**: Proprietary string detailing what kind of save was done - undefined for normal saves, but can be new, redirect (IN, RK only), or close when doing complex saves
+        - **artifactId**: If the operation created a new artifact, it's ID is put here. Always paired with the redirect or new operation, depending on whether the artifact has a separate redirect operation.
+    ??? note "registerEvent_loaded(handler: (dontClearMessages: boolean) => void)"
+        Registers an event handler on the details page to trigger when the main form data is loaded. This will be triggered each time the data is refreshed, including switching between artifacts without a full page load.
+
+        - **dontClearMessages**: Whether or not the page load being performed should clear any displayed errors native to Spira. Unlikely to be meaningful for a SpiraApp.
+    ??? note "registerEvent_dataFailure(handler: (errorMessage: PluginRestException) => void)"
+        Registers an event handler on the details page form manager for when data is not saved correctly. 
+
+        - **PluginRestException**: Object containing an exceptionType & message property
+    ??? note "registerEvent_operationReverted(handler: (statusId: number, isOpen: boolean) => void)" 
+        Registers an event handler on the details page form manager for when a status change is reverted back. 
+    ??? note "registerEvent_dropdownChanged(fieldName: string, <br> handler: (oldValue: string, newValue: string) => boolean): boolean" 
+        Registers an event handler on the [specified dropdown field](./SpiraApps-Reference.md/#available-field-names) for when its value changes. 
+
+        - **fieldName**: name of the artifact field this should listen to changes on
+        - **handler**: 
+            - **oldValue**: the value a dropdown had selected prior to user input
+            - **newValue**: the value a dropdown is changing to based on user input
+            - **return**: False to reject the transition & return the dropdown to the original value
+        - **return**: False if the SpiraAppManager could not find the field or otherwise was unable to mount the event listener 
     - **registerEvent_gridLoaded**: registers an event handler to trigger when a [specific grid](./SpiraApps-Reference.md#available-grid-ids) is loaded. A grid is loaded on page load, refresh, after a cancelled edit, and after a successful grid update/edit.
     - **registerEvent_dataPreSave**: Registers an event handler on a details page to trigger after a user has started a save operation, but before the save is submitted to the database. 
 
+=== "All Pages"
+    - **registerEvent_windowLoad**: registers an event handler to run on full page load (e.g. to load a dashboard widget on page load). Note that while the page may be fully loaded, some data or logic on the page may still be processing or loading.
+
+=== "Dashboards"
+    - **registerEvent_dashboardUpdated**: registers an event handler on dashboard pages when the release dropdown is changed. This can be useful when a user changes the release on the product dashboard.
 
 === "Example"
 


### PR DESCRIPTION
Updated our function lists to include TS function signatures & explain the parameters in an easier to parse manner for how devlopers would read such things in code. I also split up long lists into sub-categories in some cases.

I also made some updates to how information is formatted for sections which only contain 1 function but an explainer of the parameters & renamed certain sections to more closely match their current usage. Mostly label updates & we arguably could collapse these sections into other sections now that we have a strong pattern for conveying functions in a way that does not take up vertical page space without a user expanding a block. 

Want to especially flag the localStorage functions at the bottom of the file for a thorough review as I changed that significantly instead of just refactoring. 
Previously, it said that developers could only store using the APP_GUID as a key (1 localStorage entry per SpiraApp), but the code does no such checking & that likely would result in users storing some JSON of an object for complex data when they could just store something in multiple keys. 
I have re-explained it to tell developers they can have multiple keys, but all keys must contain the APP_GUID to avoid key conflicts with other SpiraApps & Spira's native functionality or else we will not publish it. Let me know if that is wrong for some reason & we do not want to support SpiraApps using multiple LocalStorage keys. 